### PR TITLE
Changing the maven dependency version and netty-tcnative-boringssl-static newly added

### DIFF
--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <!--Specify pravegaVersion in properties or use default: 0.10.0-->
         <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.9.0-2766.2515791-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.10.1</pravegaVersion>
+        <pravegaVersion>0.11.1</pravegaVersion>
     </properties>
 
     <repositories>
@@ -68,7 +68,15 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>1.36.0</version>
+            <!-- NOTE: Please, use 1.36.0 for Pravega Client 0.10.* builds -->
+            <!-- NOTE: Please, use 1.36.2 for Pravega Client 0.11.* builds -->
+            <version>1.39.0</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.48.Final</version>
         </dependency>
 
         <dependency>
@@ -81,13 +89,13 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.73.Final</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>3.4.0</version>
+            <version>3.19.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…atic added newly.

Changing the version of Pravega from 0.10.1 to 0.11.0. Changing the version of below artifactId
grpc-all - 1.36.0 to 1.39.0
netty-all - 4.1.65.Final to 4.1.73.Final
protobuf-java-util - 3.4.0 to 3.19.4
Adding the maven dependency for netty-tcnative-boringssl-static